### PR TITLE
LPS-75038 Store the innerHTML for a tooltip in IE in a variable befor…

### DIFF
--- a/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -555,8 +555,17 @@ AUI.add(
 						if (labelNode) {
 							var tipNode = labelNode.one('.taglib-icon-help');
 
+							var innerHTMLCopy;
+							if (A.UA.ie > 0) {
+								innerHTMLCopy = tipNode.get('innerHTML').toString();
+							}
+
 							if (Lang.isValue(label) && Lang.isNode(labelNode)) {
 								labelNode.html(A.Escape.html(label));
+							}
+
+							if(innerHTMLCopy) {
+								tipNode.set('innerHTML', innerHTMLCopy);
 							}
 
 							var fieldDefinition = instance.getFieldDefinition();


### PR DESCRIPTION
…e the innerHTML is deleted as IE doesn't copy the value, it only references it